### PR TITLE
Add the Ability to Open 'telnet' Scheme URLs from other Apps

### DIFF
--- a/Resources/Common/Base.lproj/Main.storyboard
+++ b/Resources/Common/Base.lproj/Main.storyboard
@@ -12,7 +12,7 @@
         <!--Connect View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" userLabel="Connect View Controller" customClass="ConnectViewController" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="Connect View Controller" id="BYZ-38-t0r" userLabel="Connect View Controller" customClass="ConnectViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC" userLabel="Connect View">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Resources/Common/Info.plist
+++ b/Resources/Common/Info.plist
@@ -2,6 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>telnet</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/Source/AppDelegate.mm
+++ b/Source/AppDelegate.mm
@@ -30,11 +30,15 @@
 #include <OpenHLX/Common/Errors.hpp>
 #include <OpenHLX/Utilities/Assert.hpp>
 
+#import "ConnectViewController.h"
+#import "UIViewController+TopViewController.h"
+
 
 using namespace HLX::Client;
 using namespace HLX::Common;
 using namespace HLX::Model;
 using namespace Nuovations;
+
 
 @interface AppDelegate ()
 {
@@ -235,6 +239,77 @@ using namespace Nuovations;
 - (void)applicationWillTerminate: (UIApplication *)aApplication
 {
     return;
+}
+
+/**
+ *  @brief
+ *    Asks the delegate to open a resource specified by a URL, and
+ *    provides a dictionary of launch options.
+ *
+ *  @param[in]  aApplication  A pointer to the application singleton.
+ *  @param[in]  aURL          A pointer to the URL to open.
+ *  @param[in]  aOptions      A pointer to an immutable dictionary or URL
+ *                            handling options. This dictionary may
+ *                            contain zero or more of the following
+ *                            key/value pairs: @a
+ *                            UIApplicationOpenURLOptionsSourceApplicationKey,
+ *                            a key to a value that is the string of
+ *                            the bundle ID of the app that sent the
+ *                            openURL request to this app; @a
+ *                            UIApplicationOpenURLOptionsAnnotationKey,
+ *                            a key to a value that contains the
+ *                            information passed to a document
+ *                            interaction controller object's
+ *                            annotation property; and
+ *                            UIApplicationOpenURLOptionsOpenInPlaceKey,
+ *                            a key to a value that is a Boolean
+ *                            indicating whether a document must be
+ *                            copied before you use it.
+ *
+ *  @returns
+ *     YES if the delegate successfully handled the request or NO if
+ *     the attempt to open the URL resource failed.
+ *
+ */
+- (BOOL)application: (UIApplication *)aApplication openURL: (NSURL *)aURL options: (NSDictionary<UIApplicationOpenURLOptionsKey, id> *)aOptions
+{
+    NSString * lScheme = [aURL scheme];
+    BOOL       lRetval = NO;
+
+    if (mApplicationController->SupportsScheme((__bridge CFStringRef)lScheme))
+    {
+        NSString * const   lStoryboardName = @"Main";
+        UIStoryboard *     lStoryboard;
+        NSString *const    lViewControllerId = @"Connect View Controller";
+        UIViewController * lViewController;
+
+
+        // Load the connect view controller programmatically.
+
+        lStoryboard = [UIStoryboard storyboardWithName: lStoryboardName
+                                                bundle: nullptr];
+        nlREQUIRE(lStoryboard != nullptr, done);
+
+        lViewController = [lStoryboard instantiateViewControllerWithIdentifier: lViewControllerId];
+        nlREQUIRE(lViewController != nullptr, done);
+
+        // Present the refreshing view controller modally, consuming
+        // the full screen.
+
+        lViewController.modalPresentationStyle = UIModalPresentationFullScreen;
+        lViewController.modalTransitionStyle   = UIModalTransitionStyleCoverVertical;
+
+        [[UIViewController topViewController] presentViewController: lViewController
+                                                           animated: true
+                                                         completion: ^(void) {
+            [static_cast<ConnectViewController *>(lViewController) openURL: aURL];
+        }];
+
+        lRetval = YES;
+    }
+
+done:
+    return (lRetval);
 }
 
 // MARK: Instance Methods

--- a/Source/ConnectViewController.h
+++ b/Source/ConnectViewController.h
@@ -159,6 +159,10 @@ class ApplicationControllerDelegate;
 
 - (void) onConnectCancelled: (UIAlertAction *)aAlertAction;
 
+// MARK: Workers
+
+- (void) openNetworkAddressOrName: (NSString *)aNetworkAddressOrName;
+
 @end
 
 #endif // CONNECTVIEWCONTROLLER_H

--- a/Source/ConnectViewController.h
+++ b/Source/ConnectViewController.h
@@ -162,6 +162,7 @@ class ApplicationControllerDelegate;
 // MARK: Workers
 
 - (void) openNetworkAddressOrName: (NSString *)aNetworkAddressOrName;
+- (void) openURL: (NSURL *)aURL;
 
 @end
 

--- a/Source/ConnectViewController.mm
+++ b/Source/ConnectViewController.mm
@@ -463,8 +463,9 @@ done:
  *  @param[in]  aNetworkAddressOrName  A pointer to a string containing
  *                                     the IP address, host name, IP
  *                                     address and port, host name
- *                                     and port, or URL to open (that
- *                                     is, connect to).
+ *                                     and port, or URL of the HLX
+ *                                     server to open (that is,
+ *                                     connect to).
  *
  */
 - (void) openNetworkAddressOrName: (NSString *)aNetworkAddressOrName
@@ -483,6 +484,41 @@ done:
 
 done:
     return;
+}
+
+/**
+ *  @brief
+ *    Attempt to open (that is, connect to) the HLX server with the
+ *    specified URL.
+ *
+ *  @note
+ *    This will close (that is, disconnect) any existing HLX server
+ *    connection and will populate the @a
+ *    mNetworkAddressOrNameTextField field with the URL.
+ *
+ *  @param[in]  aURL  A pointer to the URL of the HLX server to open
+ *                    (that is, connect to).
+ *
+ */
+- (void) openURL: (NSURL *)aURL
+{
+    NSString *lNetworkAddressOrNameString = [aURL absoluteString];
+
+    // Disconnect from any existing HLX server that might currently be
+    // connected.
+
+    mApplicationController->Disconnect();
+
+    // Populate the network address or name text field such that the
+    // connection history is correctly populated if the connection is
+    // successful and such that the user has visibility into what URL
+    // is being opened.
+
+    self.mNetworkAddressOrNameTextField.text = lNetworkAddressOrNameString;
+
+    // Peform the actual open (that is, connection).
+
+    [self openNetworkAddressOrName: lNetworkAddressOrNameString];
 }
 
 - (void) controllerWillResolve: (HLX::Client::Application::Controller &)aController withHost: (const char *)aHost

--- a/Source/ConnectViewController.mm
+++ b/Source/ConnectViewController.mm
@@ -386,19 +386,12 @@ done:
 
     if ((aSender == self.mConnectButton) || (aSender == self.mNetworkAddressOrNameTextField))
     {
-        Status             lStatus;
-        NSString          *lNetworkAddressOrName = nullptr;
-
-
-        // Disable the connect button while connecting.
-
-        self.mConnectButton.enabled = NO;
+        NSString *lNetworkAddressOrName = nullptr;
 
         lNetworkAddressOrName = self.mNetworkAddressOrNameTextField.text;
         nlREQUIRE(lNetworkAddressOrName != nullptr, done);
 
-        lStatus = mApplicationController->Connect([lNetworkAddressOrName UTF8String]);
-        nlREQUIRE_SUCCESS(lStatus, done);
+        [self openNetworkAddressOrName: lNetworkAddressOrName];
     }
 
  done:
@@ -457,6 +450,39 @@ done:
 - (void) onConnectCancelled: (UIAlertAction *)aAlertAction
 {
     mApplicationController->Disconnect();
+}
+
+// MARK: Workers
+
+/**
+ *  @brief
+ *    Attempt to open (that is, connect to) the HLX server with the
+ *    specified IP address, host name, IP address and port, host name
+ *    and port, or URL.
+ *
+ *  @param[in]  aNetworkAddressOrName  A pointer to a string containing
+ *                                     the IP address, host name, IP
+ *                                     address and port, host name
+ *                                     and port, or URL to open (that
+ *                                     is, connect to).
+ *
+ */
+- (void) openNetworkAddressOrName: (NSString *)aNetworkAddressOrName
+{
+    Status lStatus;
+
+    nlREQUIRE(aNetworkAddressOrName != nullptr, done);
+    nlREQUIRE([aNetworkAddressOrName length] > 0, done);
+
+    // Disable the connect button while connecting.
+
+    self.mConnectButton.enabled = NO;
+
+    lStatus = mApplicationController->Connect([aNetworkAddressOrName UTF8String]);
+    nlREQUIRE_SUCCESS(lStatus, done);
+
+done:
+    return;
 }
 
 - (void) controllerWillResolve: (HLX::Client::Application::Controller &)aController withHost: (const char *)aHost

--- a/openhlx-ios.xcodeproj/project.pbxproj
+++ b/openhlx-ios.xcodeproj/project.pbxproj
@@ -2191,7 +2191,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "name.grant.erickson.Open-HLX-Installer";
+				PRODUCT_BUNDLE_IDENTIFIER = "name.erickson.grant.Open-HLX-Installer";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2226,7 +2226,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "name.grant.erickson.Open-HLX-Installer";
+				PRODUCT_BUNDLE_IDENTIFIER = "name.erickson.grant.Open-HLX-Installer";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
This addresses #1, by adding the appropriate entries to the app _Info.plist_ and by adding support for the `application:openURL:options:` `UIApplication` delegate method.