### PR TITLE
Open HLX: Fix Hidden Dynamic Zone Detail View Table Sections

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+1.0.3 (2024-12-29)
+
+    * Addressed an issue in the Open HLX app in which unused content
+      otherwise intended for the Open HLX Installer app were incorrectly
+      rendering under the zone detail navigation view "< Back" element.
+
 1.0.2 (2024-12-22)
 
     * Updated to reflect upstream OpenHLX 1.2.2 package.

--- a/Resources/Common/Info.plist
+++ b/Resources/Common/Info.plist
@@ -24,7 +24,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.2</string>
+	<string>1.0.3</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/Source/ZoneDetailViewController.mm
+++ b/Source/ZoneDetailViewController.mm
@@ -623,26 +623,9 @@ static bool shouldHideSection(const NSIndexPath *aIndexPath)
 
 - (CGFloat)tableView: (UITableView *)aTableView heightForHeaderInSection: (NSInteger)aSection
 {
-    CGFloat lRetval;
-
-
-    switch (aSection)
-    {
-
-#if !(OPENHLX_INSTALLER)
-    case kSectionBalance:
-    case kSectionSound:
-        lRetval = 0.1f;
-        break;
-#endif // !(OPENHLX_INSTALLER)
-
-    case kSectionSource:
-    case kSectionVolume:
-    default:
-        lRetval = [super tableView: aTableView heightForHeaderInSection: aSection];
-        break;
-
-    }
+    const CGFloat lRetval = (shouldHideSection(aSection) ?
+                             0.01f :
+                             [super tableView: aTableView heightForHeaderInSection: aSection]);
 
     return (lRetval);
 }

--- a/Source/ZoneDetailViewController.mm
+++ b/Source/ZoneDetailViewController.mm
@@ -639,6 +639,24 @@ static bool shouldHideSection(const NSIndexPath *aIndexPath)
     return (lRetval);
 }
 
+- (nullable NSString *)tableView: (UITableView *)aTableView titleForHeaderInSection: (NSInteger)aSection
+{
+    NSString * lRetval = (shouldHideSection(aSection) ?
+                          @"" :
+                         [super tableView: aTableView titleForHeaderInSection: aSection]);
+
+    return (lRetval);
+}
+
+- (nullable NSString *)tableView: (UITableView *)aTableView titleForFooterInSection: (NSInteger)aSection
+{
+    NSString * lRetval = (shouldHideSection(aSection) ?
+                          @"" :
+                         [super tableView: aTableView titleForFooterInSection: aSection]);
+
+    return (lRetval);
+}
+
 - (void)tableView: (UITableView *)aTableView accessoryButtonTappedForRowWithIndexPath: (NSIndexPath *)aIndexPath;
 {
 #if OPENHLX_INSTALLER

--- a/Source/ZoneDetailViewController.mm
+++ b/Source/ZoneDetailViewController.mm
@@ -538,6 +538,47 @@ done:
 // returning zero (0) and the latter three returning 0.1f, effectively
 // suppressing the display of the sections and/or rows.
 
+/**
+ *  @brief
+ *    Return whether the specified table view section should be hidden.
+ *
+ *  @param[in]  aSection  A reference to the immutable table view
+ *                        section identifier for which to determine
+ *                        whether it should be hidden.
+ *
+ *  @returns
+ *    True if the table view section associated with @a aSection should
+ *    be hidden; otherwise, false.
+ *
+ *  @private
+ *
+ */
+static bool shouldHideSection(const NSInteger &aSection)
+{
+    bool lRetval = false;
+
+
+    switch (aSection)
+    {
+
+#if !(OPENHLX_INSTALLER)
+    case kSectionBalance:
+    case kSectionSound:
+        lRetval = true;
+        break;
+#endif // !(OPENHLX_INSTALLER)
+
+    case kSectionSource:
+    case kSectionVolume:
+    default:
+        lRetval = false;
+        break;
+
+    }
+
+    return (lRetval);
+}
+
 - (NSInteger)tableView: (UITableView *)aTableView numberOfRowsInSection: (NSInteger)aSection
 {
     NSInteger lRetval;

--- a/Source/ZoneDetailViewController.mm
+++ b/Source/ZoneDetailViewController.mm
@@ -614,27 +614,9 @@ static bool shouldHideSection(const NSIndexPath *aIndexPath)
 
 - (CGFloat)tableView: (UITableView *)aTableView heightForRowAtIndexPath: (NSIndexPath *)aIndexPath
 {
-    const NSUInteger lSection = aIndexPath.section;
-    CGFloat          lRetval;
-
-
-    switch (lSection)
-    {
-
-#if !(OPENHLX_INSTALLER)
-    case kSectionBalance:
-    case kSectionSound:
-        lRetval = 0.1f;
-        break;
-#endif // !(OPENHLX_INSTALLER)
-
-    case kSectionSource:
-    case kSectionVolume:
-    default:
-        lRetval = [super tableView: aTableView heightForRowAtIndexPath: aIndexPath];
-        break;
-
-    }
+    const CGFloat lRetval = (shouldHideSection(aIndexPath) ?
+                             0.01f :
+                             [super tableView: aTableView heightForRowAtIndexPath: aIndexPath]);
 
     return (lRetval);
 }

--- a/Source/ZoneDetailViewController.mm
+++ b/Source/ZoneDetailViewController.mm
@@ -579,6 +579,30 @@ static bool shouldHideSection(const NSInteger &aSection)
     return (lRetval);
 }
 
+/**
+ *  @brief
+ *    Return whether the table view section associated with the
+ *    specified table view index path should be hidden.
+ *
+ *  @param[in]  aIndexPath  A pointer to the immutable table view
+ *                          index path for which to determine
+ *                          whether it should be hidden.
+ *
+ *  @returns
+ *    True if the table view section associated with @a aIndexPath
+ *    should be hidden; otherwise, false.
+ *
+ *  @private
+ *
+ */
+static bool shouldHideSection(const NSIndexPath *aIndexPath)
+{
+    const NSUInteger lSection = aIndexPath.section;
+    const bool lRetval = shouldHideSection(lSection);
+
+    return (lRetval);
+}
+
 - (NSInteger)tableView: (UITableView *)aTableView numberOfRowsInSection: (NSInteger)aSection
 {
     NSInteger lRetval;

--- a/Source/ZoneDetailViewController.mm
+++ b/Source/ZoneDetailViewController.mm
@@ -537,6 +537,19 @@ done:
 // and sound sections are suppressed with numberOfRowsInSection
 // returning zero (0) and the latter three returning 0.1f, effectively
 // suppressing the display of the sections and/or rows.
+//
+// We also need to set the header and footer text to "clear"; otherwise, the
+// hidden sections will render atop one another and under the "< Back"
+// navigation view element. To accomplish this, the following methods are
+// overridden:
+//
+//   - titleForHeaderInSection
+//   - titleForFooterInSection
+//   - viewForHeaderInSection
+//   - viewForFooterInSection
+//
+// The following static functions overloads, shouldHideSection, encapsulate
+// the determination of whether to hide a section for the above overrides.
 
 /**
  *  @brief

--- a/Source/ZoneDetailViewController.mm
+++ b/Source/ZoneDetailViewController.mm
@@ -632,26 +632,9 @@ static bool shouldHideSection(const NSIndexPath *aIndexPath)
 
 - (CGFloat)tableView: (UITableView *)aTableView heightForFooterInSection: (NSInteger)aSection
 {
-    CGFloat lRetval;
-
-
-    switch (aSection)
-    {
-
-#if !(OPENHLX_INSTALLER)
-    case kSectionBalance:
-    case kSectionSound:
-        lRetval = 0.1f;
-        break;
-#endif // !(OPENHLX_INSTALLER)
-
-    case kSectionSource:
-    case kSectionVolume:
-    default:
-        lRetval = [super tableView: aTableView heightForFooterInSection: aSection];
-        break;
-
-    }
+    const CGFloat lRetval = (shouldHideSection(aSection) ?
+                             0.01f :
+                             [super tableView: aTableView heightForFooterInSection: aSection]);
 
     return (lRetval);
 }

--- a/Source/ZoneDetailViewController.mm
+++ b/Source/ZoneDetailViewController.mm
@@ -605,26 +605,9 @@ static bool shouldHideSection(const NSIndexPath *aIndexPath)
 
 - (NSInteger)tableView: (UITableView *)aTableView numberOfRowsInSection: (NSInteger)aSection
 {
-    NSInteger lRetval;
-
-
-    switch (aSection)
-    {
-
-#if !(OPENHLX_INSTALLER)
-    case kSectionBalance:
-    case kSectionSound:
-        lRetval = 0;
-        break;
-#endif // !(OPENHLX_INSTALLER)
-
-    case kSectionSource:
-    case kSectionVolume:
-    default:
-        lRetval = [super tableView: aTableView numberOfRowsInSection: aSection];
-        break;
-
-    }
+    const NSInteger lRetval = (shouldHideSection(aSection) ?
+                               0 :
+                               [super tableView: aTableView numberOfRowsInSection: aSection]);
 
     return (lRetval);
 }

--- a/Source/ZoneDetailViewController.mm
+++ b/Source/ZoneDetailViewController.mm
@@ -657,6 +657,24 @@ static bool shouldHideSection(const NSIndexPath *aIndexPath)
     return (lRetval);
 }
 
+- (nullable UIView *)tableView: (UITableView *)aTableView viewForHeaderInSection: (NSInteger)aSection
+{
+    UIView * lRetval = (shouldHideSection(aSection) ?
+                        nullptr :
+                        [super tableView: aTableView viewForHeaderInSection: aSection]);
+
+    return (lRetval);
+}
+
+- (nullable UIView *)tableView: (UITableView *)aTableView viewForFooterInSection: (NSInteger)aSection
+{
+    UIView * lRetval = (shouldHideSection(aSection) ?
+                        nullptr :
+                        [super tableView: aTableView viewForFooterInSection: aSection]);
+
+    return (lRetval);
+}
+
 - (void)tableView: (UITableView *)aTableView accessoryButtonTappedForRowWithIndexPath: (NSIndexPath *)aIndexPath;
 {
 #if OPENHLX_INSTALLER


### PR DESCRIPTION
This addresses #7 by correcting an issue in the _Open HLX_ app in which unused content otherwise intended for the _Open HLX Installer_ app were incorrectly rendering under the zone detail navigation view `< Back` element.